### PR TITLE
Update for usage with Terraform 0.13.

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source = "digitalocean/digitalocean"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
This example does not work with the most recent versions of Terraform:

```
$ terraform init

Initializing the backend...

Initializing provider plugins...
- Finding latest version of hashicorp/digitalocean...
- Finding latest version of hashicorp/null...
- Installing hashicorp/null v3.0.0...
- Installed hashicorp/null v3.0.0 (signed by HashiCorp)

Error: Failed to install providers

Could not find required providers, but found possible alternatives:

  hashicorp/digitalocean -> digitalocean/digitalocean

If these suggestions look correct, upgrade your configuration with the
following command:
    terraform 0.13upgrade .
```

This PR adds a `versions.tf` file that is configured for looking up the DigitalOcean provider and installing it from the Terraform registry.