### PR TITLE
Update slugs used in config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains [Terraform](https://www.terraform.io/) and [Ansible](ht
 
 This demo will create the following infrastructure using Terraform:
 
-- Two 512mb Droplets in the NYC3 datacenter running Ubuntu 16.04
+- Two 1 GB Droplets in the NYC3 datacenter running Ubuntu 20.04
 - One DigitalOcean Load Balancer to route HTTP traffic to the Droplets
 - One DigitalOcean Cloud Firewall to lock down communication between the Droplets and the outside world
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -10,18 +10,18 @@ provider "digitalocean" {
 
 # create two demo droplets
 resource "digitalocean_droplet" "demo-01" {
-  image    = "ubuntu-16-04-x64"
+  image    = "ubuntu-20-04-x64"
   name     = "demo-01"
   region   = "nyc3"
-  size     = "512mb"
+  size     = "s-1vcpu-1gb"
   ssh_keys = [var.ssh_fingerprint]
 }
 
 resource "digitalocean_droplet" "demo-02" {
-  image    = "ubuntu-16-04-x64"
+  image    = "ubuntu-20-04-x64"
   name     = "demo-02"
   region   = "nyc3"
-  size     = "512mb"
+  size     = "s-1vcpu-1gb"
   ssh_keys = [var.ssh_fingerprint]
 }
 


### PR DESCRIPTION
This updates the Terraform configuration to use the `s-1vcpu-1gb` plan in place of the legacy `512mb` plan, twice the memory for the same price. It also updates the base image used from `ubuntu-16-04-x64` to `ubuntu-20-04-x64`, the current LTS. I've verified the Ansible playbook runs against this new version successfully.